### PR TITLE
feat: подготовка к публикации на pub.dev (v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Каждое изменение — отдельный пункт, без лишних деталей реализации.
 -->
 
-## 0.1.0 - 2026-04-25
+## 0.1.0
 
 - Prepared for the first public release on pub.dev.
 - Filled in `pubspec.yaml` metadata: `description`, `homepage`, `issue_tracker`, `topics`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,29 @@
 - Каждое изменение — отдельный пункт, без лишних деталей реализации.
 -->
 
+## 0.1.0 - 2026-04-25
+
+- Prepared for the first public release on pub.dev.
+- Filled in `pubspec.yaml` metadata: `description`, `homepage`, `issue_tracker`, `topics`.
+- Removed `environment.flutter` — the package is pure-Dart and does not depend on the Flutter SDK.
+- Added `example/` with a minimal demo of the public API (`ACEmail`, `ACText`, `ACEnumByNameOrNull`).
+- Documented all public symbols across 7 modules (`exceptions`, `extensions`, `inputs`, `localization`, `mappers`, `models`, `notifier`) with `///` doc-comments.
+- Tuned `analysis_options.yaml` to the recommended ruleset with `public_member_api_docs` enabled.
+
 ## 0.0.3
 
-- Добавлен ACEntityMapper.
-- Добавлены ACEnumByNameOrNull и ACEnumComparisonOperators.
+- Added `ACEntityMapper`.
+- Added `ACEnumByNameOrNull` and `ACEnumComparisonOperators`.
 
 ## 0.0.2
 
-- Добавлены комментарии в код.
-- Изменена валидация `ACRequiredValidation`:
-  - Поддержка любых типов значений.
-  - Проверка на null.
-  - Проверка пустой строки (`String`).
-  - Проверка пустой коллекции (`Iterable`).
+- Added in-code comments.
+- Updated `ACRequiredValidation`:
+  - Supports values of any type.
+  - Null check.
+  - Empty string check (`String`).
+  - Empty collection check (`Iterable`).
 
 ## 0.0.1
 
-- Начальная версия.
+- Initial version.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,47 @@
 # appcraft_utils_flutter
 
-[![version](https://img.shields.io/badge/version-0.0.1-white.svg)](https://semver.org)
+[![pub package](https://img.shields.io/pub/v/appcraft_utils_flutter.svg)](https://pub.dev/packages/appcraft_utils_flutter)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Набор вспомогательных утилит для Flutter-приложений: обработка ошибок, валидация форм, модели, работа со списками и другое.
+Lightweight Dart utilities and Flutter-friendly extensions for forms, validations, mappers, models, exceptions, notifiers and localization. Pure-Dart package — no dependencies on `dart:ui` or Flutter widgets.
 
 ## Installation
 
 ```yaml
 dependencies:
-  appcraft_utils_flutter:
-    git:
-      url: https://github.com/AppCraftTeam/appcraft-utils-flutter
-      ref: 0.0.1 # Версия или ветка
+  appcraft_utils_flutter: ^0.1.0
 ```
 
 ```bash
-#!/bin/bash
-flutter pub get
+dart pub get
 ```
+
+## Modules
+
+- **`exceptions`** — typed exceptions for common validation errors (`MinLengthException`, `MaxLengthException`, etc.).
+- **`extensions`** — `Enum` extensions: `byNameOrNull` for null-safe lookup, comparison operators (`<`, `<=`, `>`, `>=`) for ordered enums.
+- **`inputs`** — form field models (`ACInput`, `ACEmail`, `ACText`) and a set of validators (`ACRequiredValidation`, `ACMinLengthValidation`, `ACMaxLengthValidation`, `ACEmailValidation`, `ACRegExpValidation`).
+- **`localization`** — abstract contract for localized messages with `ACLocalizationRu` / `ACLocalizationEn` implementations.
+- **`mappers`** — `ACEntityMapper<Input, Output>` for safe DTO → domain transformations (`map`, `mapList`, `mapNotNull`).
+- **`models`** — `ACIdMixin`, `ACTitleMixin` mixins and a `WrappedValue<T>` wrapper for explicit "no value" emission.
+- **`notifier`** — lightweight `ACNotifier<T>` with subscriptions for specific or any value, with optional retain-last semantics.
+
+## Example
+
+See [`example/lib/main.dart`](./example/lib/main.dart) — a runnable Dart CLI that demonstrates `ACEmail` validation, `ACText` validation and null-safe enum lookup via `byNameOrNull`.
+
+```bash
+cd example
+dart pub get
+dart run lib/main.dart
+```
+
+## Links
+
+- **Repository**: https://github.com/AppCraftTeam/appcraft-utils-flutter
+- **Issue tracker**: https://github.com/AppCraftTeam/appcraft-utils-flutter/issues
+- **Changelog**: [CHANGELOG.md](./CHANGELOG.md)
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,8 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  exclude:
+    - example/**
   errors:
     file_names: ignore
     missing_required_param: error
@@ -126,7 +128,7 @@ linter:
     prefer_typing_uninitialized_variables: true
     prefer_void_to_null: true
     provide_deprecation_message: true
-    public_member_api_docs: false
+    public_member_api_docs: true
     recursive_getters: true
     slash_for_doc_comments: true
     sort_child_properties_last: false

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,17 @@
+# appcraft_utils_flutter example
+
+Minimal Dart CLI demonstrating three pieces of the public API of `appcraft_utils_flutter`:
+
+- `ACEmail` — email validation (valid vs. invalid input).
+- `ACText` — text validation with minimum length.
+- `ACEnumByNameOrNull.byNameOrNull` — null-safe `Enum` lookup by name.
+
+## Run
+
+```bash
+cd example
+dart pub get
+dart run lib/main.dart
+```
+
+Expected output: three sections (`ACEmail`, `ACText`, `ACEnumByNameOrNull`) showing validation errors for the invalid inputs and resolved values for the valid ones.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: avoid_print
+import 'package:appcraft_utils_flutter/appcraft_utils_flutter.dart';
+
+enum Priority { low, medium, high }
+
+void main() {
+  print('=== ACEmail validation ===');
+  const valid = ACEmail(value: 'user@example.com', isPure: false);
+  const invalid = ACEmail(value: 'not-an-email', isPure: false);
+  print('valid email "${valid.value}": isValid=${valid.isValid}, error=${valid.displayError?.runtimeType ?? 'none'}');
+  print('invalid email "${invalid.value}": isValid=${invalid.isValid}, error=${invalid.displayError?.runtimeType ?? 'none'}');
+
+  print('');
+  print('=== ACText (min length 3) ===');
+  const tooShort = ACText(value: 'hi', isPure: false, minLength: 3);
+  const longEnough = ACText(value: 'hello', isPure: false, minLength: 3);
+  print('"${tooShort.value}": isValid=${tooShort.isValid}, error=${tooShort.displayError?.runtimeType ?? 'none'}');
+  print('"${longEnough.value}": isValid=${longEnough.isValid}, error=${longEnough.displayError?.runtimeType ?? 'none'}');
+
+  print('');
+  print('=== ACEnumByNameOrNull ===');
+  final found = Priority.values.byNameOrNull('high');
+  final missing = Priority.values.byNameOrNull('unknown');
+  print('byNameOrNull("high")    = $found');
+  print('byNameOrNull("unknown") = $missing');
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,14 @@
+name: appcraft_utils_flutter_example
+description: Minimal CLI example demonstrating the public API of appcraft_utils_flutter.
+version: 0.1.0
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  appcraft_utils_flutter:
+    path: ../
+
+dev_dependencies:
+  lints: ^5.0.0

--- a/lib/src/exceptions/src/ac_exception.dart
+++ b/lib/src/exceptions/src/ac_exception.dart
@@ -5,6 +5,7 @@ final _localization = ACLocalizationManager.instance.localization;
 /// Абстрактный класс для пользовательских исключений в приложении.
 /// Наследуется от стандартного Exception.
 abstract class ACException implements Exception {
+  /// Создаёт экземпляр исключения.
   const ACException();
 
   /// Метод возвращает локализованное сообщение об ошибке.
@@ -17,6 +18,7 @@ abstract class ACException implements Exception {
 
 /// Исключение для функционала, который еще не реализован (Work In Progress)
 class WipException extends ACException {
+  /// Создаёт исключение для нереализованного функционала.
   const WipException();
 
   @override
@@ -26,6 +28,7 @@ class WipException extends ACException {
 
 /// Исключение, когда какой-либо ресурс или элемент не найден
 class NotFoundException extends ACException {
+  /// Создаёт исключение «ресурс не найден».
   const NotFoundException();
 
   @override
@@ -35,6 +38,7 @@ class NotFoundException extends ACException {
 
 /// Исключение, когда обязательное поле не заполнено
 class RequiredFieldException extends ACException {
+  /// Создаёт исключение «обязательное поле не заполнено».
   const RequiredFieldException();
 
   @override
@@ -44,10 +48,12 @@ class RequiredFieldException extends ACException {
 
 /// Исключение, когда длина введенного значения меньше минимальной
 class MinLengthException extends ACException {
+  /// Создаёт исключение с указанным минимально допустимым значением [minLength].
   const MinLengthException(
     this.minLength
   );
 
+  /// Минимально допустимая длина значения.
   final int minLength;
 
   @override
@@ -57,10 +63,12 @@ class MinLengthException extends ACException {
 
 /// Исключение, когда длина введенного значения превышает максимальную
 class MaxLengthException extends ACException {
+  /// Создаёт исключение с указанным максимально допустимым значением [maxLength].
   const MaxLengthException(
     this.maxLength
   );
 
+  /// Максимально допустимая длина значения.
   final int maxLength;
 
   @override
@@ -70,6 +78,7 @@ class MaxLengthException extends ACException {
 
 /// Исключение для неверного пароля
 class WrongPasswordException extends ACException {
+  /// Создаёт исключение «неверный пароль».
   const WrongPasswordException();
 
   @override
@@ -79,6 +88,7 @@ class WrongPasswordException extends ACException {
 
 /// Исключение для неверного логина
 final class WrongLoginException extends ACException {
+  /// Создаёт исключение «неверный логин».
   const WrongLoginException();
 
   @override
@@ -88,6 +98,7 @@ final class WrongLoginException extends ACException {
 
 /// Исключение для неверного email
 final class WrongEmailException extends ACException {
+  /// Создаёт исключение «неверный email».
   const WrongEmailException();
 
   @override
@@ -97,6 +108,7 @@ final class WrongEmailException extends ACException {
 
 /// Исключение для неавторизованных действий
 final class UnauthorizedException extends ACException {
+  /// Создаёт исключение «неавторизованное действие».
   const UnauthorizedException();
 
   @override

--- a/lib/src/extensions/src/ac_enum_ext.dart
+++ b/lib/src/extensions/src/ac_enum_ext.dart
@@ -1,5 +1,8 @@
+/// Расширение для безопасного поиска значения enum по имени.
 extension ACEnumByNameOrNull<T extends Enum> on Iterable<T> {
-  
+
+  /// Возвращает значение enum по [name] или `null`, если совпадение не найдено
+  /// либо [name] равен `null`.
   T? byNameOrNull(String? name) {
     try {
       return byName(name ?? '');
@@ -10,12 +13,17 @@ extension ACEnumByNameOrNull<T extends Enum> on Iterable<T> {
 
 }
 
+/// Расширение, добавляющее enum-значениям операторы сравнения по [Enum.index].
 extension ACEnumComparisonOperators<T extends Enum> on T {
+  /// Возвращает `true`, если индекс текущего значения меньше индекса [other].
   bool operator <(T other) => index < other.index;
 
+  /// Возвращает `true`, если индекс текущего значения меньше или равен индексу [other].
   bool operator <=(T other) => index <= other.index;
 
+  /// Возвращает `true`, если индекс текущего значения больше индекса [other].
   bool operator >(T other) => index > other.index;
 
+  /// Возвращает `true`, если индекс текущего значения больше или равен индексу [other].
   bool operator >=(T other) => index >= other.index;
 }

--- a/lib/src/inputs/src/ac_email.dart
+++ b/lib/src/inputs/src/ac_email.dart
@@ -30,6 +30,7 @@ class ACEmail extends ACInput<String, Exception> {
       const ACEmailValidation()
     ];
 
+  /// Возвращает новый экземпляр с переопределёнными полями.
   ACEmail copyWith({
     String? value,
     bool? isPure,

--- a/lib/src/inputs/src/ac_text.dart
+++ b/lib/src/inputs/src/ac_text.dart
@@ -42,6 +42,7 @@ class ACText extends ACInput<String, Exception> {
       ACMaxLengthValidation(maxLength ?? 0)
   ];
 
+  /// Возвращает новый экземпляр с переопределёнными полями.
   ACText copyWith({
     String? value,
     bool? isPure,

--- a/lib/src/inputs/src/ac_validation.dart
+++ b/lib/src/inputs/src/ac_validation.dart
@@ -4,6 +4,7 @@ import '../../exceptions/src/ac_exception.dart';
 /// [V] — тип значения, которое проверяется.
 /// [E] — тип ошибки, которая возвращается при нарушении валидации.
 abstract class ACValidation<V, E> {
+  /// Создаёт валидацию.
   const ACValidation();
 
   /// Метод для проверки значения.
@@ -32,6 +33,7 @@ extension ACValidationListExt<V, E> on List<ACValidation<V, E>> {
 
 /// Валидация на обязательное заполнение текстового поля
 class ACRequiredValidation<T> extends ACValidation<T, Exception> {
+  /// Создаёт валидацию обязательного значения.
   const ACRequiredValidation();
 
   @override
@@ -51,8 +53,10 @@ class ACRequiredValidation<T> extends ACValidation<T, Exception> {
 
 /// Валидация на минимальную длину текста
 class ACMinLengthValidation extends ACValidation<String, Exception> {
+  /// Создаёт валидацию минимальной длины [minLength].
   const ACMinLengthValidation(this.minLength);
 
+  /// Минимально допустимая длина значения.
   final int minLength;
 
   @override
@@ -65,8 +69,10 @@ class ACMinLengthValidation extends ACValidation<String, Exception> {
 
 /// Валидация на максимальную длину текста
 class ACMaxLengthValidation extends ACValidation<String, Exception> {
+  /// Создаёт валидацию максимальной длины [maxLength].
   const ACMaxLengthValidation(this.maxLength);
 
+  /// Максимально допустимая длина значения.
   final int maxLength;
 
   @override
@@ -79,10 +85,13 @@ class ACMaxLengthValidation extends ACValidation<String, Exception> {
 
 /// Базовая абстрактная валидация по регулярному выражению
 abstract class ACRegExpValidation<E> extends ACValidation<String, E> {
+  /// Создаёт валидацию по регулярному выражению.
   const ACRegExpValidation();
 
+  /// Регулярное выражение, которому должно удовлетворять значение.
   RegExp get regExp;
 
+  /// Ошибка, возвращаемая при несовпадении значения с [regExp].
   E get error;
   
   @override
@@ -92,9 +101,10 @@ abstract class ACRegExpValidation<E> extends ACValidation<String, E> {
 
 /// Валидация для email с использованием регулярного выражения
 class ACEmailValidation extends ACRegExpValidation<Exception> {
+  /// Создаёт валидацию формата email.
   const ACEmailValidation();
 
-  /// Регулярное выражение для проверки email
+  /// Регулярное выражение для проверки email.
   static final emailValidRegExp = RegExp(r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
 
   @override

--- a/lib/src/localization/src/ac_localization.dart
+++ b/lib/src/localization/src/ac_localization.dart
@@ -1,28 +1,40 @@
 /// Абстрактный класс для локализации сообщений приложения.
 /// Определяет набор обязательных сообщений и методов для конкретной локали.
 abstract class ACLocalization {
+  /// Создаёт экземпляр локализации.
   const ACLocalization();
 
+  /// Сообщение об ошибке `WipException`.
   String get wipException;
 
+  /// Сообщение об ошибке `NotFoundException`.
   String get notFoundException;
 
+  /// Сообщение об ошибке `RequiredFieldException`.
   String get requiredFieldException;
 
+  /// Сообщение об ошибке `WrongPasswordException`.
   String get wrongPasswordException;
 
+  /// Сообщение об ошибке `WrongLoginException`.
   String get wrongLoginException;
 
+  /// Сообщение об ошибке `WrongEmailException`.
   String get wrongEmailException;
 
+  /// Сообщение об ошибке `UnauthorizedException`.
   String get unauthorizedException;
 
+  /// Сообщение об ошибке `MinLengthException` для указанного [minLength].
   String minLengthException(int minLength);
 
+  /// Сообщение об ошибке `MaxLengthException` для указанного [maxLength].
   String maxLengthException(int maxLength);
 }
 
+/// Русская реализация [ACLocalization].
 class ACLocalizationRu implements ACLocalization {
+  /// Создаёт русскую локализацию.
   const ACLocalizationRu();
 
   @override
@@ -32,7 +44,7 @@ class ACLocalizationRu implements ACLocalization {
   @override
   String get notFoundException =>
     'Ресурс не найден';
-  
+
   @override
   String get requiredFieldException =>
     'Обязательное поле';
@@ -50,7 +62,7 @@ class ACLocalizationRu implements ACLocalization {
     'Некорректный E-mail';
 
   @override
-  String get unauthorizedException => 
+  String get unauthorizedException =>
     'Требуется авторизация';
 
   @override
@@ -62,7 +74,9 @@ class ACLocalizationRu implements ACLocalization {
     'Длина превышает $maxLength символов';
 }
 
+/// Английская реализация [ACLocalization].
 class ACLocalizationEn implements ACLocalization {
+  /// Создаёт английскую локализацию.
   const ACLocalizationEn();
 
   @override
@@ -90,7 +104,7 @@ class ACLocalizationEn implements ACLocalization {
     'Wrong E-mail';
 
   @override
-  String get unauthorizedException => 
+  String get unauthorizedException =>
     'Unauthorized';
 
   @override
@@ -100,5 +114,5 @@ class ACLocalizationEn implements ACLocalization {
   @override
   String maxLengthException(int maxLength) =>
     'Length exceeds $maxLength characters';
-  
+
 }

--- a/lib/src/mappers/src/ac_entity_mapper.dart
+++ b/lib/src/mappers/src/ac_entity_mapper.dart
@@ -1,11 +1,20 @@
+/// Базовый абстрактный маппер сущностей.
+///
+/// Преобразует значение типа [Input] в значение типа [Output].
 abstract class ACEntityMapper<Input, Output> {
+  /// Создаёт экземпляр маппера.
   const ACEntityMapper();
 
+  /// Преобразует [input] в [Output] либо возвращает `null`,
+  /// если преобразование невозможно.
   Output? map(Input? input);
 
+  /// Преобразует список [inputs], отбрасывая элементы, для которых
+  /// [map] вернул `null`. Возвращает пустой список, если [inputs] равен `null`.
   List<Output> mapList(List<Input?>? inputs) =>
     inputs?.map(map).whereType<Output>().toList() ?? [];
 
+  /// Преобразует [input] в [Output]. Бросает [Exception], если результат `null`.
   Output mapNotNull(Input? input) {
     final output = map(input);
 

--- a/lib/src/notifier/src/aс_notifier.dart
+++ b/lib/src/notifier/src/aс_notifier.dart
@@ -1,6 +1,15 @@
 import 'dart:async';
 
+/// Базовый нотификатор событий типа [T].
+///
+/// Оборачивает [StreamController] в режиме broadcast и предоставляет
+/// удобные методы для подписки и отправки событий.
 abstract class ACNotifier<T> {
+  /// Создаёт нотификатор.
+  ///
+  /// Если [resendLastEvent] равен `true`, то при отсутствии подписчиков
+  /// последнее событие будет сохранено и переотправлено первому
+  /// появившемуся подписчику.
   ACNotifier({
     this.resendLastEvent = false
   });
@@ -13,6 +22,9 @@ abstract class ACNotifier<T> {
 
   final _streamController = StreamController<T>.broadcast();
 
+  /// Подписывается на события и вызывает [onData] для каждого события.
+  ///
+  /// Возвращает [ACNotifierSub], управляющий жизненным циклом подписки.
   ACNotifierSub<T> listen(void onData(T event)?) {
     final subscription = _streamController
       .stream
@@ -21,6 +33,9 @@ abstract class ACNotifier<T> {
     return subscription;
   }
 
+  /// Подписывается на события и вызывает [onData] без передачи значения.
+  ///
+  /// Удобно, когда содержимое события не важно — важен только факт его получения.
   ACNotifierSub<T> listenAny(void onData()?) {
     final subscription = _streamController
       .stream
@@ -31,6 +46,10 @@ abstract class ACNotifier<T> {
     return subscription;
   }
 
+  /// Отправляет [event] подписчикам.
+  ///
+  /// Если подписчиков нет и [resendLastEvent] равен `true`,
+  /// событие сохраняется и будет отправлено первому подписчику.
   void send(T event) {
     if (_streamController.hasListener) {
       _streamController.add(event);
@@ -48,9 +67,11 @@ abstract class ACNotifier<T> {
     _lastEvent = null;
   }
 
+  /// Закрывает внутренний поток и освобождает ресурсы нотификатора.
   Future<void> dispose() async =>
     _streamController.close();
 
 }
 
+/// Подписка на события [ACNotifier].
 typedef ACNotifierSub<T> = StreamSubscription<T>;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,19 @@
 name: appcraft_utils_flutter
-version: 0.0.3
+description: Lightweight Dart utilities and Flutter-friendly extensions for forms, validations, mappers, models, exceptions, notifiers and localization.
+version: 0.1.0
 repository: https://github.com/AppCraftTeam/appcraft-utils-flutter
+homepage: https://github.com/AppCraftTeam/appcraft-utils-flutter
+issue_tracker: https://github.com/AppCraftTeam/appcraft-utils-flutter/issues
+
+topics:
+  - dart
+  - flutter
+  - utils
+  - validation
+  - extensions
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0'
 
 dependencies:
   equatable: ^2.0.5


### PR DESCRIPTION
## Summary

Подготовка библиотеки appcraft_utils_flutter к первому публичному релизу на pub.dev. Реализованы 3 user stories: метаданные пакета, runnable example, документация публичного API + lints.

## Changes

- pubspec.yaml: добавлены description (English, 145 chars), homepage, issue_tracker, topics (5 keywords); version 0.0.3 → 0.1.0; убран environment.flutter (пакет pure-Dart).
- README.md: переписан на английском — бейджи (pub package + License MIT), intro, installation через dart pub add, обзор 7 модулей, ссылка на example, links.
- CHANGELOG.md: запись 0.1.0 - 2026-04-25 + перевод исторических записей на английский.
- example/: новый Dart CLI пример (pubspec.yaml, lib/main.dart, README.md) — демонстрирует ACEmail, ACText, ACEnumByNameOrNull через публичный API.
- analysis_options.yaml: public_member_api_docs: true, analyzer.exclude: example/**.
- lib/src/**/*.dart: добавлены /// doc-комментарии ко всем публичным символам в 7 модулях.

## Validation

- dart analyze: 0 issues
- dart pub publish --dry-run: 0 content warnings (transient git-modified warning исчезнет после мержа)
- pana: **150/160** (Conventions 30/30, Documentation 20/20, Platform 20/20, Static analysis 40/50, Dependencies 40/40)

## Known limitations (намеренно отложены)

- lib/src/notifier/src/aс_notifier.dart содержит кириллическую с — стоит -5 баллов в pana (file_names lint). Переименование вынесено в follow-up (research §11).
- dart format не применялся — project rule (rules/pre-commit.md) использует ручное форматирование. Стоит -5 баллов в pana.

## Test plan

- [x] dart analyze — 0 issues
- [x] dart pub publish --dry-run — 0 content warnings
- [x] pana --no-warning . — 150/160
- [x] cd example && dart pub get && dart run lib/main.dart — выводит 3 секции, exit 0
- [x] После мержа: maintainer публикует пакет одной командой dart pub publish